### PR TITLE
fix issue when adjusting the timestamp of old builds.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 0.2.1 / Unreleased
+# 0.2.2 / Unreleased
+
+# 0.2.1 / 2017-11-07
+
+# [BUGFIX] Error when checking for out-of-date resultsets
 
 # 0.2.0 / 2017-09-30
 

--- a/lib/codeclimate_circle_ci_coverage/circle_ci_1.rb
+++ b/lib/codeclimate_circle_ci_coverage/circle_ci_1.rb
@@ -25,7 +25,7 @@ class CircleCi1
         to = File.join(target_directory, "#{i}.resultset.json")
         command = "scp #{node}:#{from} #{to}"
 
-        puts "running command: #{command}"
+        puts "Downloading Result from CI Node: #{command}"
         `#{command}`
       end
     end

--- a/lib/codeclimate_circle_ci_coverage/coverage_reporter.rb
+++ b/lib/codeclimate_circle_ci_coverage/coverage_reporter.rb
@@ -45,6 +45,7 @@ class CoverageReporter
     output_result_html(merged_result)
     upload_result_file(merged_result)
     store_code_climate_payload(merged_result)
+    puts "Reporting Complete."
     true
   end
 
@@ -63,7 +64,7 @@ class CoverageReporter
     json_files.each_with_index do |resultset, i|
       resultset.each do |_command_name, data|
         result = SimpleCov::Result.from_hash(['command', i].join => data)
-        check_and_fix_result_time(result)
+        check_and_fix_result_time(result, i)
         SimpleCov::ResultMerger.store_result(result)
       end
     end
@@ -73,11 +74,11 @@ class CoverageReporter
     merged_result
   end
 
-  def check_and_fix_result_time(result)
+  def check_and_fix_result_time(result, index)
     if Time.now - result.created_at >= SimpleCov.merge_timeout
-      puts "result #{i} has a created_at from #{result.created_at} (current time #{Time.now})"
+      puts "result #{index} has a created_at from #{result.created_at} (current time #{Time.now})"
       puts "This will prevent coverage from being combined. Please check your tests for Stub-Time-related issues"
-      put "Setting result created_at to current time to avoid this issue"
+      puts "Setting result created_at to current time to avoid this issue"
       # If the result is timestamped old, it is ignored by SimpleCov
       # So we always set the created_at to Time.now so that the ResultMerger
       # doesn't discard any results

--- a/spec/coverage_reporter_spec.rb
+++ b/spec/coverage_reporter_spec.rb
@@ -36,4 +36,23 @@ describe CoverageReporter do
       # failing because creating a believable SimpleCov Result is more difficult than I thought
     end
   end
+
+  describe "#check_and_fix_result_time" do
+    context "when the time is new enough" do
+      let(:result) { OpenStruct.new(created_at: Time.now) }
+
+      it "does nothing" do
+        reporter.check_and_fix_result_time(result, 1)
+        expect(result.created_at).to be_within(1).of(Time.now)
+      end
+    end
+
+    context "when the time is in the past" do
+      let(:result) { OpenStruct.new(created_at: Time.now - 3600) }
+      it "can fix times" do
+        reporter.check_and_fix_result_time(result, 1)
+        expect(result.created_at).to be_within(1).of(Time.now)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Also adds a print statement once the coverage is complete